### PR TITLE
[stable/redis] Add persistence to read-only slaves

### DIFF
--- a/stable/redis/README.md
+++ b/stable/redis/README.md
@@ -195,6 +195,14 @@ The following table lists the configurable parameters of the Redis chart and the
 | `slave.readinessProbe.timeoutSeconds`      | When the probe times out (redis slave pod)                                                                     | `master.readinessProbe.timeoutSeconds`               |
 | `slave.readinessProbe.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed (redis slave pod)  | `master.readinessProbe.successThreshold`             |
 | `slave.readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed after having succeeded. (redis slave pod)   | `master.readinessProbe.failureThreshold`             |
+| `slave.persistence.enabled`               | Use a PVC to persist data (slave node)                                                                        | `true`                                               |
+| `slave.persistence.path`                  | Path to mount the volume at, to use other images                                                               | `/data`                                              |
+| `slave.persistence.subPath`               | Subdirectory of the volume to mount at                                                                         | `""`                                                 |
+| `slave.persistence.storageClass`          | Storage class of backing PVC                                                                                   | `generic`                                            |
+| `slave.persistence.accessModes`           | Persistent Volume Access Modes                                                                                 | `[ReadWriteOnce]`                                    |
+| `slave.persistence.size`                  | Size of data volume                                                                                            | `8Gi`                                                |
+| `slave.statefulset.updateStrategy`        | Update strategy for StatefulSet                                                                                | onDelete                                             |
+| `slave.statefulset.rollingUpdatePartition`| Partition update strategy                                                                                      | `nil`                                                |
 | `slave.podLabels`                          | Additional labels for Redis slave pod                                                                          | `master.podLabels`                                   |
 | `slave.podAnnotations`                     | Additional annotations for Redis slave pod                                                                     | `master.podAnnotations`                              |
 | `slave.schedulerName`                      | Name of an alternate scheduler                                                                                 | `nil`                                                |
@@ -279,8 +287,13 @@ sysctlImage:
       echo never > /host-sys/kernel/mm/transparent_hugepage/enabled
 ```
 
+## Notable changes
+
+### 7.0.0
+In order to improve the performance in case of slave failure, we added persistence to the read-only slaves. That means that we moved from Deployment to StatefulSets. This should not affect upgrades from previous versions of the chart, as the deployments did not contain any persistence at all.
+
 ## Upgrade
 
-## To 6.0.0
+### To 6.0.0
 
 Previous versions of the chart were using an init-container to change the permissions of the volumes. This was done in case the `securityContext` directive in the template was not enough for that (for example, with cephFS). In this new version of the chart, this container is disabled by default (which should not affect most of the deployments). If your installation still requires that init container, execute `helm upgrade` with the `--set volumePermissions.enabled=true`.

--- a/stable/redis/templates/configmap.yaml
+++ b/stable/redis/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
 {{- end }}
 {{- end }}
   replica.conf: |-
-    dir /data
+    dir {{ .Values.slave.persistence.path }}
 {{- if .Values.slave.disableCommands }}
 {{- range .Values.slave.disableCommands }}
     rename-command {{ . }} ""

--- a/stable/redis/templates/redis-slave-statefulset.yaml
+++ b/stable/redis/templates/redis-slave-statefulset.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.cluster.enabled }}
-apiVersion: extensions/v1beta1
-kind: Deployment
+apiVersion: apps/v1beta2
+kind: StatefulSet
 metadata:
   name: {{ template "redis.fullname" . }}-slave
   labels:
@@ -16,6 +16,7 @@ spec:
 {{- if .Values.cluster.slaveCount }}
   replicas: {{ .Values.cluster.slaveCount }}
 {{- end }}
+  serviceName: {{ template "redis.fullname" . }}-slave
   selector:
     matchLabels:
         release: "{{ .Release.Name }}"
@@ -71,7 +72,6 @@ spec:
         securityContext:
           runAsUser: {{ .Values.securityContext.runAsUser }}
         {{- end }}
-{{- $command := .Values.slave.command }}
         command:
         - /bin/bash
         - -c
@@ -94,8 +94,8 @@ spec:
           {{- end }}
           ARGS+=("--include" "/opt/bitnami/redis/etc/redis.conf")
           ARGS+=("--include" "/opt/bitnami/redis/etc/replica.conf")
-          {{- if .Values.master.command }}
-          {{ .Values.master.command }} "${ARGS[@]}"
+          {{- if .Values.slave.command }}
+          {{ .Values.slave.command }} "${ARGS[@]}"
           {{- else }}
           redis-server "${ARGS[@]}"
           {{- end }}
@@ -107,7 +107,7 @@ spec:
         - name: REDIS_PORT
           value: {{ .Values.slave.port | quote }}
         - name: REDIS_MASTER_PORT_NUMBER
-          value: {{ .Values.master.service.port | quote }}
+          value: {{ .Values.slave.service.port | quote }}
         {{- if .Values.usePassword }}
         {{- if .Values.usePasswordFile }}
         - name: REDIS_PASSWORD_FILE
@@ -175,8 +175,24 @@ spec:
         - name: config
           mountPath: /opt/bitnami/redis/etc
         {{- end }}
-      {{- if .Values.sysctlImage.enabled }}
+      {{- $needsVolumePermissions := and .Values.volumePermissions.enabled (and .Values.slave.persistence.enabled .Values.securityContext.enabled) }}
+      {{- if or $needsVolumePermissions .Values.sysctlImage.enabled }}
       initContainers:
+      {{- if $needsVolumePermissions }}
+      - name: volume-permissions
+        image: "{{ template "redis.volumePermissions.image" . }}"
+        imagePullPolicy: {{ default "" .Values.volumePermissions.image.pullPolicy | quote }}
+        command: ["/bin/chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}", "{{ .Values.slave.persistence.path }}"]
+        securityContext:
+          runAsUser: 0
+        resources:
+{{ toYaml .Values.volumePermissions.resources | indent 10 }}
+        volumeMounts:
+        - name: redis-data
+          mountPath: {{ .Values.slave.persistence.path }}
+          subPath: {{ .Values.slave.persistence.subPath }}
+      {{- end }}
+      {{- if .Values.sysctlImage.enabled }}
       - name: init-sysctl
         image: {{ template "redis.sysctl.image" . }}
         resources:
@@ -191,6 +207,7 @@ spec:
         securityContext:
           privileged: true
           runAsUser: 0
+      {{- end }}
       {{- end }}
       volumes:
       - name: health
@@ -207,11 +224,44 @@ spec:
         configMap:
           name: {{ template "redis.fullname" . }}
       {{- end }}
-      - name: redis-data
-        emptyDir: {}
       {{- if .Values.sysctlImage.mountHostSys }}
       - name: host-sys
         hostPath:
           path: /sys
       {{- end }}
+  {{- if and .Values.slave.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-data
+        labels:
+          app: "{{ template "redis.name" . }}"
+          component: "slave"
+          release: {{ .Release.Name | quote }}
+          heritage: {{ .Release.Service | quote }}
+      spec:
+        accessModes:
+        {{- range .Values.slave.persistence.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.slave.persistence.size | quote }}
+      {{- if .Values.slave.persistence.storageClass }}
+      {{- if (eq "-" .Values.slave.persistence.storageClass) }}
+        storageClassName: ""
+      {{- else }}
+        storageClassName: {{ .Values.slave.persistence.storageClass | quote }}
+      {{- end }}
+      {{- end }}
+  {{- end }}
+  updateStrategy:
+    type: {{ .Values.slave.statefulset.updateStrategy }}
+    {{- if .Values.slave.statefulset.rollingUpdatePartition }}
+    {{- if (eq "Recreate" .Values.slave.statefulset.updateStrategy) }}
+    rollingUpdate: null
+    {{- else }}
+    rollingUpdate:
+      partition: {{ .Values.slave.statefulset.rollingUpdatePartition }}
+    {{- end }}
+    {{- end }}
 {{- end }}

--- a/stable/redis/values-production.yaml
+++ b/stable/redis/values-production.yaml
@@ -290,6 +290,37 @@ slave:
   #     memory: 256Mi
   #     cpu: 100m
 
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    enabled: true
+    ## The path the volume will be mounted at, useful when using different
+    ## Redis images.
+    path: /data
+    ## The subdirectory of the volume to mount to, useful in dev environments
+    ## and one PV for multiple services.
+    subPath: ""
+    ## redis data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    accessModes:
+    - ReadWriteOnce
+    size: 8Gi
+
+  ## Update strategy, can be set to RollingUpdate or onDelete by default.
+  ## https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
+  statefulset:
+    updateStrategy: RollingUpdate
+    ## Partition update strategy
+    ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
+    # rollingUpdatePartition:
+
   ## Redis slave selectors and tolerations for pod assignment
   # nodeSelector: {"beta.kubernetes.io/arch": "amd64"}
   # tolerations: []

--- a/stable/redis/values.yaml
+++ b/stable/redis/values.yaml
@@ -304,6 +304,37 @@ slave:
   ## Redis slave pod priorityClassName
   # priorityClassName: {}
 
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    enabled: true
+    ## The path the volume will be mounted at, useful when using different
+    ## Redis images.
+    path: /data
+    ## The subdirectory of the volume to mount to, useful in dev environments
+    ## and one PV for multiple services.
+    subPath: ""
+    ## redis data Persistent Volume Storage Class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    accessModes:
+    - ReadWriteOnce
+    size: 8Gi
+
+  ## Update strategy, can be set to RollingUpdate or onDelete by default.
+  ## https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
+  statefulset:
+    updateStrategy: RollingUpdate
+    ## Partition update strategy
+    ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
+    # rollingUpdatePartition:
+
 ## Prometheus Exporter / Metrics
 ##
 metrics:


### PR DESCRIPTION
Signed-off-by: Javier J. Salmeron Garcia <jsalmeron@bitnami.com>


#### What this PR does / why we need it:
I am using my repository because I would like to propose a set of major changes to the stable/redis chart:

- Remove master/slave value inheritance (https://github.com/javsalgar/charts/pull/1)
- Change slaves from deployments to statefulsets (https://github.com/javsalgar/charts/pull/2)
- Add basic redis-sentinel support

Instead of putting all of them in one big PR at the same time, I would like to do three PRs and, when all are merged, then send the big one to helm/charts

This PR adds persistence to the redis slaves. The reason is that, in the case of failover, the new slave would have to sync all the data from the very beginning. In terms of performance and I/O consumption, this is problematic. If we have persistence in the slaves, according to the redis documentation (https://redis.io/topics/replication):

> When the link between the master and the slave breaks, for network issues or because a timeout is sensed in the master or the slave, the slave reconnects and attempts to proceed with a partial resynchronization: it means that it will try to just obtain the part of the stream of commands it missed during the disconnection.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
